### PR TITLE
docs: fix typo

### DIFF
--- a/docs/01-getting-started/03-react-essentials.mdx
+++ b/docs/01-getting-started/03-react-essentials.mdx
@@ -334,7 +334,7 @@ With this approach, the rendering of `<ExampleClientComponent>` and `<ExampleSer
 >
 > - This pattern is **already applied** in [layouts and pages](/docs/app/building-your-application/routing/pages-and-layouts) with the `children` prop so you don't have to create an additional wrapper component.
 > - Passing React components (JSX) to other components is not a new concept and has always been part of the React composition model.
-> - This composition strategy works across Server and Client Components because the component that receives the prop has no knowledge of **what** the prop is. It is only responsible for where the thing that it is passed should be placed.
+> - This composition strategy works across Server and Client Components because the component that receives the prop has no knowledge of **what** the prop is. It is only responsible for where the thing that is passed should be placed.
 >   - This allows the passed prop to be rendered independently, in this case, on the server, well before the Client Component is rendered on the client.
 >   - The very same strategy of "lifting content up" has been used to avoid state changes in a parent component re-rendering an imported nested child component.
 > - You're not limited to the `children` prop. You can use any prop to pass JSX.


### PR DESCRIPTION
remove misused pronoun "it"